### PR TITLE
Fixed 2 issues of type: PYTHON_E225 throughout 1 file in repo.

### DIFF
--- a/data/feedly_data.py
+++ b/data/feedly_data.py
@@ -25,7 +25,7 @@ def get_text(entry: Entry) -> BeautifulSoup:
   content = entry.json["content"]["content"] if "content" in entry.json else ""
   summary = entry.json["summary"]["content"] if "summary" in entry.json else ""
   title = entry.json["title"]
-  best=max(full_content, content, summary, title, key=len)
+  best = max(full_content, content, summary, title, key=len)
 
   return BeautifulSoup(best.replace("\n", ""), 'html.parser').text
 
@@ -160,7 +160,7 @@ class FeedlyDownloader:
 
 if __name__ == "__main__":
 
-    token ="YourToken"
+    token = "YourToken"
     downloader = FeedlyDownloader(token=token)
 
     # # One category


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.