### PR TITLE
Add the possibility to cache objects and use them in different experiment settings

### DIFF
--- a/experiments/deep_learning_with_pytorch/mlp_parameter_tuning.py
+++ b/experiments/deep_learning_with_pytorch/mlp_parameter_tuning.py
@@ -31,8 +31,20 @@ if __name__ == "__main__":
     parent_dir = Path(__file__).parent
     home_env = str(Path.home() / 'work/transfer-nlp-data')
     date = '_'.join(str(datetime.today()).split(' '))
-    ExperimentRunner.run_all(experiment=parent_dir / 'mlp_parameter_tuning.json',
-                             experiment_config=parent_dir / 'mlp_parameter_tuning.cfg',
-                             report_dir=f"{home_env}/mlp_parameter_fine_tuning/{date}",
-                             trainer_config_name='trainer',
-                             reporter_config_name='reporter', HOME=home_env)
+
+    # # Uncomment to run the sequential Runner without caching read-only objects
+    # ExperimentRunner.run_all(experiment=parent_dir / 'mlp_parameter_tuning.json',
+    #                          experiment_config=parent_dir / 'mlp_parameter_tuning.cfg',
+    #                          report_dir=f"{home_env}/mlp_parameter_fine_tuning/{date}",
+    #                          trainer_config_name='trainer',
+    #                          reporter_config_name='reporter', HOME=home_env)
+    # 
+    # 
+    # # Uncomment to run the sequential Runner with caching read-only objects
+    # ExperimentRunner.run_all(experiment=parent_dir / 'mlp_parameter_tuning_uncached.json',
+    #                          experiment_config=parent_dir / 'mlp_parameter_tuning.cfg',
+    #                          report_dir=f"{home_env}/mlp_parameter_fine_tuning/{date}",
+    #                          trainer_config_name='trainer',
+    #                          reporter_config_name='reporter',
+    #                          experiment_cache=parent_dir / 'mlp_parameter_tuning_cache.json',
+    #                          HOME=home_env)

--- a/experiments/deep_learning_with_pytorch/mlp_parameter_tuning_cache.json
+++ b/experiments/deep_learning_with_pytorch/mlp_parameter_tuning_cache.json
@@ -1,0 +1,11 @@
+{
+  "my_dataset_splits": {
+    "_name": "SurnamesDatasetMLP",
+    "data_file": "$HOME/surnames/surnames_with_splits.csv",
+    "batch_size": 128,
+    "vectorizer": {
+      "_name": "SurnamesVectorizerMLP",
+      "data_file": "$HOME/surnames/surnames_with_splits.csv"
+    }
+  }
+}

--- a/experiments/deep_learning_with_pytorch/mlp_parameter_tuning_uncached.json
+++ b/experiments/deep_learning_with_pytorch/mlp_parameter_tuning_uncached.json
@@ -1,0 +1,50 @@
+{
+  "model": {
+    "_name": "MultiLayerPerceptron",
+    "hidden_dim": "$hidden_dim",
+    "data": "$my_dataset_splits"
+  },
+  "optimizer": {
+    "_name": "Adam",
+    "lr": "$lr",
+    "params": {
+      "_name": "TrainableParameters"
+    }
+  },
+  "scheduler": {
+    "_name": "ReduceLROnPlateau",
+    "patience": 1,
+    "mode": "min",
+    "factor": 0.5
+  },
+  "trainer": {
+    "_name": "BasicTrainer",
+    "model": "$model",
+    "dataset_splits": "$my_dataset_splits",
+    "loss": {
+      "_name": "CrossEntropyLoss"
+    },
+    "optimizer": "$optimizer",
+    "gradient_clipping": 0.25,
+    "num_epochs": 5,
+    "seed": 1337,
+    "regularizer": {
+      "_name": "L1"
+    },
+    "tensorboard_logs": "$HOME/surnames/tensorboard/mlp",
+    "metrics": {
+      "accuracy": {
+        "_name": "Accuracy"
+      },
+      "loss": {
+        "_name": "LossMetric",
+        "loss_fn": {
+          "_name": "CrossEntropyLoss"
+        }
+      }
+    }
+  },
+  "reporter": {
+    "_name": "MyReporter"
+  }
+}


### PR DESCRIPTION
We'd like to enable users to cache some read-only objects, typically datasets, so that they are not re-created at each experiment setting run #47 

This PR changes the sequential ExperimentRunner class by adding an optional `experiment_cache` parameter to the `_write_config` method. 

If an `experiment_cache` json file is defined and used, then the runner instantiate its experiment objects and cache them, so that for each experiment json in the sequential run, we update their json with the cached dictionary before instantiating them.

