### PR TITLE
Refactor/custom trainers

### DIFF
--- a/experiments/bert/bert.json
+++ b/experiments/bert/bert.json
@@ -25,7 +25,7 @@
     }
   },
   "trainer": {
-    "_name": "BasicTrainer",
+    "_name": "SingleTaskTrainer",
     "model": "$model",
     "dataset_splits": "$data_loader",
     "loss": {

--- a/experiments/deep_learning_with_pytorch/cbow.json
+++ b/experiments/deep_learning_with_pytorch/cbow.json
@@ -28,7 +28,7 @@
     "factor": 0.5
   },
   "trainer": {
-    "_name": "BasicTrainer",
+    "_name": "SingleTaskTrainer",
     "model": "$model",
     "dataset_splits": "$my_dataset_splits",
     "loss": {

--- a/experiments/deep_learning_with_pytorch/mlp.json
+++ b/experiments/deep_learning_with_pytorch/mlp.json
@@ -32,7 +32,7 @@
     "factor": 0.5
   },
   "trainer": {
-    "_name": "BasicTrainer",
+    "_name": "SingleTaskTrainer",
     "model": "$model",
     "dataset_splits": "$my_dataset_splits",
     "loss": {

--- a/experiments/deep_learning_with_pytorch/mlp_parameter_tuning.json
+++ b/experiments/deep_learning_with_pytorch/mlp_parameter_tuning.json
@@ -27,7 +27,7 @@
     "factor": 0.5
   },
   "trainer": {
-    "_name": "BasicTrainer",
+    "_name": "SingleTaskTrainer",
     "model": "$model",
     "dataset_splits": "$my_dataset_splits",
     "loss": {

--- a/experiments/deep_learning_with_pytorch/mlp_parameter_tuning.py
+++ b/experiments/deep_learning_with_pytorch/mlp_parameter_tuning.py
@@ -38,8 +38,8 @@ if __name__ == "__main__":
     #                          report_dir=f"{home_env}/mlp_parameter_fine_tuning/{date}",
     #                          trainer_config_name='trainer',
     #                          reporter_config_name='reporter', HOME=home_env)
-    # 
-    # 
+
+
     # # Uncomment to run the sequential Runner with caching read-only objects
     # ExperimentRunner.run_all(experiment=parent_dir / 'mlp_parameter_tuning_uncached.json',
     #                          experiment_config=parent_dir / 'mlp_parameter_tuning.cfg',

--- a/experiments/deep_learning_with_pytorch/mlp_parameter_tuning_uncached.json
+++ b/experiments/deep_learning_with_pytorch/mlp_parameter_tuning_uncached.json
@@ -18,7 +18,7 @@
     "factor": 0.5
   },
   "trainer": {
-    "_name": "BasicTrainer",
+    "_name": "SingleTaskTrainer",
     "model": "$model",
     "dataset_splits": "$my_dataset_splits",
     "loss": {

--- a/experiments/deep_learning_with_pytorch/newsClassifier.json
+++ b/experiments/deep_learning_with_pytorch/newsClassifier.json
@@ -34,7 +34,7 @@
     "optimizer": "$my_optimizer"
   },
   "trainer": {
-    "_name": "BasicTrainer",
+    "_name": "SingleTaskTrainer",
     "model": "$my_model",
     "dataset_splits": "$my_dataset_splits",
     "loss": {

--- a/experiments/deep_learning_with_pytorch/surnameClassifier.json
+++ b/experiments/deep_learning_with_pytorch/surnameClassifier.json
@@ -27,7 +27,7 @@
     "factor": 0.5
   },
   "trainer": {
-    "_name": "BasicTrainer",
+    "_name": "SingleTaskTrainer",
     "model": "$model",
     "dataset_splits": "$my_dataset_splits",
     "loss": {

--- a/experiments/deep_learning_with_pytorch/surnamesGeneration.json
+++ b/experiments/deep_learning_with_pytorch/surnamesGeneration.json
@@ -31,7 +31,7 @@
     "_name": "OutputTransformSequence"
   },
   "trainer": {
-    "_name": "BasicTrainer",
+    "_name": "SingleTaskTrainer",
     "model": "$model",
     "dataset_splits": "$my_dataset_splits",
     "loss": {

--- a/experiments/deep_learning_with_pytorch/surnamesRNN.json
+++ b/experiments/deep_learning_with_pytorch/surnamesRNN.json
@@ -28,7 +28,7 @@
     "factor": 0.5
   },
   "trainer": {
-    "_name": "BasicTrainer",
+    "_name": "SingleTaskTrainer",
     "model": "$model",
     "dataset_splits": "$my_dataset_splits",
     "loss": {

--- a/experiments/deep_learning_with_pytorch/training.py
+++ b/experiments/deep_learning_with_pytorch/training.py
@@ -10,43 +10,47 @@ logger = logging.getLogger(__name__)
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     home_env = str(Path.home() / 'work/transfer-nlp-data')
-    surname_paths = ['./deep_learning_with_pytorch/mlp.json',
-                     './deep_learning_with_pytorch/surnamesRNN.json',
-                     './deep_learning_with_pytorch/surnameClassifier.json',
-                     './deep_learning_with_pytorch/surnamesGeneration.json'
-                     ]
-    cbow_path = './deep_learning_with_pytorch/cbow.json'
-    news_path = './deep_learning_with_pytorch/newsClassifier.json'
+    # surname_paths = ['./deep_learning_with_pytorch/mlp.json',
+    #                  './deep_learning_with_pytorch/surnamesRNN.json',
+    #                  './deep_learning_with_pytorch/surnameClassifier.json',
+    #                  './deep_learning_with_pytorch/surnamesGeneration.json'
+    #                  ]
+    # cbow_path = './deep_learning_with_pytorch/cbow.json'
+    # news_path = './deep_learning_with_pytorch/newsClassifier.json'
+    #
+    # for path in surname_paths:
+    #     logger.info(f"Launching test for experiment {path}")
+    #     experiment = ExperimentConfig(path, HOME=home_env)
+    #     experiment['trainer'].train()
+    #     if 'predictor' in experiment:
+    #         input_json = {
+    #             "inputs": ["Zhang",
+    #                        "Mueller", 'Mahmoud', "Rastapopoulos"]}
+    #         output_json = experiment['predictor'].json_to_json(input_json=input_json)
+    #         logger.info(input_json)
+    #         logger.info(output_json)
+    #
+    # logger.info(f"Launching test for experiment {cbow_path}")
+    # path = cbow_path
+    # experiment = ExperimentConfig(path, HOME=home_env)
+    # experiment['trainer'].train()
+    # input_json = {
+    #     "inputs": ["I go to and take notes"]}
+    # output_json = experiment['predictor'].json_to_json(input_json=input_json)
+    # logger.info(input_json)
+    # logger.info(output_json)
+    #
+    # logger.info(f"Launching test for experiment {news_path}")
+    # path = news_path
+    # experiment = ExperimentConfig(path, HOME=home_env)
+    # experiment['trainer'].train()
+    # input_json = {
+    #     "inputs": ["Banking financing Asset Manager Gets OK To Appeal €15M Fee Payout Ruling",
+    #                "NASA's New Planet-Hunting Telescope Just Found Its First Earth-Sized World"]}
+    # output_json = experiment['predictor'].json_to_json(input_json=input_json)
+    # logger.info(input_json)
+    # logger.info(output_json)
 
-    for path in surname_paths:
-        logger.info(f"Launching test for experiment {path}")
-        experiment = ExperimentConfig(path, HOME=home_env)
-        experiment['trainer'].train()
-        if 'predictor' in experiment:
-            input_json = {
-                "inputs": ["Zhang",
-                           "Mueller", 'Mahmoud', "Rastapopoulos"]}
-            output_json = experiment['predictor'].json_to_json(input_json=input_json)
-            logger.info(input_json)
-            logger.info(output_json)
-
-    logger.info(f"Launching test for experiment {cbow_path}")
-    path = cbow_path
+    path = './deep_learning_with_pytorch/newsClassifier.json'
     experiment = ExperimentConfig(path, HOME=home_env)
     experiment['trainer'].train()
-    input_json = {
-        "inputs": ["I go to and take notes"]}
-    output_json = experiment['predictor'].json_to_json(input_json=input_json)
-    logger.info(input_json)
-    logger.info(output_json)
-
-    logger.info(f"Launching test for experiment {news_path}")
-    path = news_path
-    experiment = ExperimentConfig(path, HOME=home_env)
-    experiment['trainer'].train()
-    input_json = {
-        "inputs": ["Banking financing Asset Manager Gets OK To Appeal €15M Fee Payout Ruling",
-                   "NASA's New Planet-Hunting Telescope Just Found Its First Earth-Sized World"]}
-    output_json = experiment['predictor'].json_to_json(input_json=input_json)
-    logger.info(input_json)
-    logger.info(output_json)

--- a/experiments/deep_learning_with_pytorch/training.py
+++ b/experiments/deep_learning_with_pytorch/training.py
@@ -10,47 +10,43 @@ logger = logging.getLogger(__name__)
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     home_env = str(Path.home() / 'work/transfer-nlp-data')
-    # surname_paths = ['./deep_learning_with_pytorch/mlp.json',
-    #                  './deep_learning_with_pytorch/surnamesRNN.json',
-    #                  './deep_learning_with_pytorch/surnameClassifier.json',
-    #                  './deep_learning_with_pytorch/surnamesGeneration.json'
-    #                  ]
-    # cbow_path = './deep_learning_with_pytorch/cbow.json'
-    # news_path = './deep_learning_with_pytorch/newsClassifier.json'
-    #
-    # for path in surname_paths:
-    #     logger.info(f"Launching test for experiment {path}")
-    #     experiment = ExperimentConfig(path, HOME=home_env)
-    #     experiment['trainer'].train()
-    #     if 'predictor' in experiment:
-    #         input_json = {
-    #             "inputs": ["Zhang",
-    #                        "Mueller", 'Mahmoud', "Rastapopoulos"]}
-    #         output_json = experiment['predictor'].json_to_json(input_json=input_json)
-    #         logger.info(input_json)
-    #         logger.info(output_json)
-    #
-    # logger.info(f"Launching test for experiment {cbow_path}")
-    # path = cbow_path
-    # experiment = ExperimentConfig(path, HOME=home_env)
-    # experiment['trainer'].train()
-    # input_json = {
-    #     "inputs": ["I go to and take notes"]}
-    # output_json = experiment['predictor'].json_to_json(input_json=input_json)
-    # logger.info(input_json)
-    # logger.info(output_json)
-    #
-    # logger.info(f"Launching test for experiment {news_path}")
-    # path = news_path
-    # experiment = ExperimentConfig(path, HOME=home_env)
-    # experiment['trainer'].train()
-    # input_json = {
-    #     "inputs": ["Banking financing Asset Manager Gets OK To Appeal €15M Fee Payout Ruling",
-    #                "NASA's New Planet-Hunting Telescope Just Found Its First Earth-Sized World"]}
-    # output_json = experiment['predictor'].json_to_json(input_json=input_json)
-    # logger.info(input_json)
-    # logger.info(output_json)
+    surname_paths = ['./deep_learning_with_pytorch/mlp.json',
+                     './deep_learning_with_pytorch/surnamesRNN.json',
+                     './deep_learning_with_pytorch/surnameClassifier.json',
+                     './deep_learning_with_pytorch/surnamesGeneration.json'
+                     ]
+    cbow_path = './deep_learning_with_pytorch/cbow.json'
+    news_path = './deep_learning_with_pytorch/newsClassifier.json'
 
-    path = './deep_learning_with_pytorch/newsClassifier.json'
+    for path in surname_paths:
+        logger.info(f"Launching test for experiment {path}")
+        experiment = ExperimentConfig(path, HOME=home_env)
+        experiment['trainer'].train()
+        if 'predictor' in experiment:
+            input_json = {
+                "inputs": ["Zhang",
+                           "Mueller", 'Mahmoud', "Rastapopoulos"]}
+            output_json = experiment['predictor'].json_to_json(input_json=input_json)
+            logger.info(input_json)
+            logger.info(output_json)
+
+    logger.info(f"Launching test for experiment {cbow_path}")
+    path = cbow_path
     experiment = ExperimentConfig(path, HOME=home_env)
     experiment['trainer'].train()
+    input_json = {
+        "inputs": ["I go to and take notes"]}
+    output_json = experiment['predictor'].json_to_json(input_json=input_json)
+    logger.info(input_json)
+    logger.info(output_json)
+
+    logger.info(f"Launching test for experiment {news_path}")
+    path = news_path
+    experiment = ExperimentConfig(path, HOME=home_env)
+    experiment['trainer'].train()
+    input_json = {
+        "inputs": ["Banking financing Asset Manager Gets OK To Appeal €15M Fee Payout Ruling",
+                   "NASA's New Planet-Hunting Telescope Just Found Its First Earth-Sized World"]}
+    output_json = experiment['predictor'].json_to_json(input_json=input_json)
+    logger.info(input_json)
+    logger.info(output_json)

--- a/tests/plugins/test_trainer.py
+++ b/tests/plugins/test_trainer.py
@@ -6,7 +6,7 @@ import ignite
 
 from transfer_nlp.plugins.config import ExperimentConfig
 from transfer_nlp.plugins.regularizers import L1
-from transfer_nlp.plugins.trainers import BasicTrainer
+from transfer_nlp.plugins.trainers import SingleTaskTrainer
 from .trainer_utils import *
 
 EXPERIMENT = {
@@ -38,7 +38,7 @@ EXPERIMENT = {
         "factor": 0.5
     },
     "trainer": {
-        "_name": "BasicTrainer",
+        "_name": "SingleTaskTrainer",
         "model": "$model",
         "dataset_splits": "$my_dataset_splits",
         "loss": {
@@ -61,8 +61,7 @@ EXPERIMENT = {
                     "_name": "CrossEntropyLoss"
                 }
             }
-        },
-        "finetune": False
+        }
     }
 
 }
@@ -87,7 +86,6 @@ class RegistryTest(unittest.TestCase):
         self.assertEqual(trainer.num_epochs, 5)
         self.assertIsInstance(trainer.regularizer, L1)
         self.assertEqual(trainer.gradient_clipping, 0.25)
-        self.assertEqual(trainer.finetune, False)
         self.assertEqual(trainer.embeddings_name, None)
         self.assertEqual(trainer.forward_params, ['x_in', 'apply_softmax'])
         # trainer.train()
@@ -97,7 +95,7 @@ class RegistryTest(unittest.TestCase):
         self.assertIsInstance(optimizer, torch.optim.Adam)
 
         trainer = trainer.experiment_config.factories['trainer'].create()
-        self.assertIsInstance(trainer, BasicTrainer)
+        self.assertIsInstance(trainer, SingleTaskTrainer)
 
     def test_setup(self):
         e = copy.deepcopy(EXPERIMENT)

--- a/transfer_nlp/plugins/trainers.py
+++ b/transfer_nlp/plugins/trainers.py
@@ -213,9 +213,6 @@ class BaseIgniteTrainer(TrainerABC):
             store_metrics(metrics=metrics, mode="test")
             logger.info(f"Test Results - Epoch: {trainer.state.epoch} {print_metrics(metrics)}")
 
-    def custom_setup(self):
-        raise NotImplementedError
-
     def _forward(self, batch):
         model_inputs = {}
         for p in self.forward_params:
@@ -230,9 +227,11 @@ class BaseIgniteTrainer(TrainerABC):
 
         return self.model(**model_inputs)
 
+    @abstractmethod
     def update_engine(self, engine, batch):
         raise NotImplementedError
 
+    @abstractmethod
     def infer_engine(self, engine, batch):
         raise NotImplementedError
 


### PR DESCRIPTION
We currently have a `BasicTrainer` which is already quite complex to change without re-writing everything. 
This PR brings:

- make the infer and update methods from the ignite training handler implementable, so that it is easier to build new training schemes by e.g. just implementing new update / infer
- custom_setup for ignite: some ignite setups are almost always needed (metrics tracking etc), some depend on applications (gradients tracking, cosine annealing scheduler...). Here we let the user implement a custom setup