### PR TITLE
Bug/change envs

### DIFF
--- a/tests/plugins/test_config.py
+++ b/tests/plugins/test_config.py
@@ -245,15 +245,15 @@ class RegistryTest(unittest.TestCase):
                         "is_available": "$HOME"},
                     {
                         "_name": "DemoIsAvailable",
-                        "is_available": "$HOMEPATH"},
-                    "$HOME"
+                        "is_available": "$VAL"},
+                    "$HOMEPATH"
                 ]
             }
         }
-        e = ExperimentConfig(experiment, HOME='/tmp', HOMEPATH=Path('/tmp2'), SVAL=7)
+        e = ExperimentConfig(experiment, HOME='/tmp', HOMEPATH=Path('/tmp2'), SVAL=7, VAL=True)
         self.assertEqual(e['data2'].param_list[0].is_available, '/tmp')
-        self.assertEqual(e['data2'].param_list[1].is_available, '/tmp2')
-        self.assertEqual(e['data2'].param_list[2], '/tmp')
+        self.assertEqual(e['data2'].param_list[1].is_available, True)
+        self.assertEqual(e['data2'].param_list[2], '/tmp2')
 
 
     def test_literal_injection(self):

--- a/tests/plugins/test_config.py
+++ b/tests/plugins/test_config.py
@@ -41,6 +41,23 @@ class DemoDefaults:
 
 
 @register_plugin
+class DemoDefaultsList:
+
+    def __init__(self, strval: str, intval1: int = 5, intval2: int = None, param_list: List = [0]):
+        self.strval = strval
+        self.intval1 = intval1
+        self.intval2 = intval2
+        self.param_list = param_list
+
+
+@register_plugin
+class DemoIsAvailable:
+
+    def __init__(self, is_available: bool = False):
+        self.is_available = is_available
+
+
+@register_plugin
 class DemoComplexDefaults:
 
     def __init__(self, strval: str, obj: DemoDefaults = None):  # use different param and property names as additonal check
@@ -210,6 +227,31 @@ class RegistryTest(unittest.TestCase):
         self.assertEqual(e['data2'].strval, 'foo')
         self.assertEqual(e['data2'].intval1, 7)
         self.assertIsNone(e['data2'].intval2)
+
+        experiment = {
+            'path': "$HOME/foo/bar",
+            'path2': "$HOMEPATH/foo/bar",
+            'data': {
+                '_name': "DemoWithStr",
+                'strval': "$HOME/foo/bar/bis"
+            },
+            'data2': {
+                '_name': "DemoDefaultsList",
+                'strval': "foo",
+                'intval1': "$SVAL",
+                'param_list': [
+                    {
+                        "_name": "DemoIsAvailable",
+                        "is_available": "$HOME"},
+                    {
+                        "_name": "DemoIsAvailable",
+                        "is_available": "$HOMEPATH"}
+                ]
+            }
+        }
+        e = ExperimentConfig(experiment, HOME='/tmp', HOMEPATH=Path('/tmp2'), SVAL=7)
+        self.assertEqual(e['data2'].param_list[0].is_available, '/tmp')
+        self.assertEqual(e['data2'].param_list[1].is_available, '/tmp2')
 
     def test_literal_injection(self):
         experiment = {

--- a/tests/plugins/test_config.py
+++ b/tests/plugins/test_config.py
@@ -245,13 +245,16 @@ class RegistryTest(unittest.TestCase):
                         "is_available": "$HOME"},
                     {
                         "_name": "DemoIsAvailable",
-                        "is_available": "$HOMEPATH"}
+                        "is_available": "$HOMEPATH"},
+                    "$HOME"
                 ]
             }
         }
         e = ExperimentConfig(experiment, HOME='/tmp', HOMEPATH=Path('/tmp2'), SVAL=7)
         self.assertEqual(e['data2'].param_list[0].is_available, '/tmp')
         self.assertEqual(e['data2'].param_list[1].is_available, '/tmp2')
+        self.assertEqual(e['data2'].param_list[2], '/tmp')
+
 
     def test_literal_injection(self):
         experiment = {

--- a/transfer_nlp/plugins/config.py
+++ b/transfer_nlp/plugins/config.py
@@ -160,19 +160,14 @@ def _replace_env_variables(dico: Dict, env: Dict) -> None:
 
         return v_upd
 
-    def recursive_replace(my_item: Union[Dict, List]):
+    def recursive_replace(my_item: Union[Dict, List, str]):
 
         if isinstance(my_item, dict):
             for k, v in my_item.items():
                 if not isinstance(v, dict) and not isinstance(v, list):
                     v = do_env_subs(v)
                     my_item[k] = v
-                elif isinstance(v, list) and all(not isinstance(vv, dict) and not isinstance(vv, list) for vv in v):
-                    upd = []
-                    for vv in v:
-                        if not isinstance(vv, list) and not isinstance(vv, dict):
-                            upd.append(do_env_subs(vv))
-                    my_item[k] = upd
+
                 elif isinstance(v, dict):
                     recursive_replace(my_item[k])
                 elif isinstance(v, list):
@@ -180,8 +175,11 @@ def _replace_env_variables(dico: Dict, env: Dict) -> None:
                 else:
                     pass
         elif isinstance(my_item, list):
-            for item in my_item:
-                recursive_replace(item)
+            for i, item in enumerate(my_item):
+                if not isinstance(item, list) and not isinstance(item, dict):
+                    my_item[i] = do_env_subs(item)
+                else:
+                    recursive_replace(item)
 
     recursive_replace(my_item=dico)
 

--- a/transfer_nlp/plugins/config.py
+++ b/transfer_nlp/plugins/config.py
@@ -160,23 +160,30 @@ def _replace_env_variables(dico: Dict, env: Dict) -> None:
 
         return v_upd
 
-    def recursive_replace(dico: Dict):
+    def recursive_replace(my_item: Union[Dict, List]):
 
-        for k, v in dico.items():
-            if not isinstance(v, dict) and not isinstance(v, list):
-                v = do_env_subs(v)
-                dico[k] = v
-            elif isinstance(v, list) and all(not isinstance(vv, dict) and not isinstance(vv, list) for vv in v):
-                upd = []
-                for vv in v:
-                    upd.append(do_env_subs(vv))
-                    dico[k] = upd
-            elif isinstance(v, dict):
-                recursive_replace(dico[k])
-            else:
-                pass
+        if isinstance(my_item, dict):
+            for k, v in my_item.items():
+                if not isinstance(v, dict) and not isinstance(v, list):
+                    v = do_env_subs(v)
+                    my_item[k] = v
+                elif isinstance(v, list) and all(not isinstance(vv, dict) and not isinstance(vv, list) for vv in v):
+                    upd = []
+                    for vv in v:
+                        if not isinstance(vv, list) and not isinstance(vv, dict):
+                            upd.append(do_env_subs(vv))
+                    my_item[k] = upd
+                elif isinstance(v, dict):
+                    recursive_replace(my_item[k])
+                elif isinstance(v, list):
+                    recursive_replace(my_item[k])
+                else:
+                    pass
+        elif isinstance(my_item, list):
+            for item in my_item:
+                recursive_replace(item)
 
-    recursive_replace(dico=dico)
+    recursive_replace(my_item=dico)
 
 
 class ExperimentConfig:


### PR DESCRIPTION
There were an issue in the `_replace_env_variables ` function, which were bringing issues for certain setups, e.g. it could not change env variables with lists.

The fix allows to change env variables in a recursive way with (potentially nested) lists and dicts