### PR TITLE
change name to qualname

### DIFF
--- a/tests/plugins/test_config.py
+++ b/tests/plugins/test_config.py
@@ -538,7 +538,7 @@ class RegistryTest(unittest.TestCase):
             self.fail()
         except BadParameter as b:
             self.assertEqual(b.param, 'bad_param')
-            self.assertEqual(b.clazz, 'DemoWithInt')
+            self.assertEqual(b.registrable, 'DemoWithInt')
 
     def test_bad_plugin(self):
 
@@ -551,7 +551,7 @@ class RegistryTest(unittest.TestCase):
             ExperimentConfig(experiment)
             self.fail()
         except UnknownPluginException as e:
-            self.assertEqual(e.clazz, 'NoConfig')
+            self.assertEqual(e.registrable, 'NoConfig')
 
         experiment = {
             "item": {
@@ -567,7 +567,7 @@ class RegistryTest(unittest.TestCase):
             ExperimentConfig(experiment)
             self.fail()
         except UnknownPluginException as e:
-            self.assertEqual(e.clazz, 'NoConfig')
+            self.assertEqual(e.registrable, 'NoConfig')
 
         experiment = {
             "item": {
@@ -583,7 +583,7 @@ class RegistryTest(unittest.TestCase):
             ExperimentConfig(experiment)
             self.fail()
         except UnknownPluginException as e:
-            self.assertEqual(e.clazz, 'NoConfig')
+            self.assertEqual(e.registrable, 'NoConfig')
 
     def test_recursive_list(self):
         experiment = {

--- a/tests/plugins/test_config.py
+++ b/tests/plugins/test_config.py
@@ -123,9 +123,33 @@ class Pipeline:
 
     def __init__(self, steps: List):
         self.steps = steps
+   
+
+class DemoClassMethod:
+    
+    def __init__(self, param: int):
+        
+        self.param = param
+    
+    @classmethod
+    def from_example(cls):
+        return cls(1)
+    
+
+register_plugin(DemoClassMethod.from_example)
 
 
 class RegistryTest(unittest.TestCase):
+    
+    def test_class_method(self):
+        
+        experiment = {
+            "my_object": {
+                "_name": "DemoClassMethod.from_example"
+            }
+        }
+        e = ExperimentConfig(experiment)
+        self.assertEqual(e['my_object'].param, 1)
 
     def test_recursive_definition(self):
         experiment = {

--- a/tests/plugins/test_config.py
+++ b/tests/plugins/test_config.py
@@ -136,7 +136,7 @@ class DemoClassMethod:
         return cls(1)
     
 
-register_plugin(DemoClassMethod.from_example)
+register_plugin(DemoClassMethod.from_example, alias='from_example_alias_name')
 
 
 class RegistryTest(unittest.TestCase):
@@ -145,7 +145,7 @@ class RegistryTest(unittest.TestCase):
         
         experiment = {
             "my_object": {
-                "_name": "DemoClassMethod.from_example"
+                "_name": "from_example_alias_name"
             }
         }
         e = ExperimentConfig(experiment)

--- a/tests/runner/test_experiment_runner.py
+++ b/tests/runner/test_experiment_runner.py
@@ -10,6 +10,36 @@ from transfer_nlp.plugins.trainers import TrainerABC
 from transfer_nlp.runner.experiment_runner import ExperimentRunner
 
 
+@register_plugin
+class MockTrainer(TrainerABC):
+    def __init__(self, bool_param, int_param, str_param, float_param, env_param):
+        self.bool_param = bool_param
+        self.int_param = int_param
+        self.str_param = str_param
+        self.float_param = float_param
+        self.env_param = env_param
+        self.trained = False
+
+    def train(self):
+        ExperimentRunnerTest._trainer_calls += 1
+        if self.trained:
+            raise ValueError()
+        self.trained = True
+
+
+@register_plugin
+class MockReporter(ReporterABC):
+    def __init__(self):
+        self.reported = False
+
+    def report(self, name: str, experiment: ExperimentConfig, report_dir: Path):
+        ExperimentRunnerTest._configs[name] = experiment
+        ExperimentRunnerTest._reporter_calls += 1
+        if self.reported:
+            raise ValueError()
+
+        self.reported = True
+
 class ExperimentRunnerTest(TestCase):
     _reporter_calls = 0
     _trainer_calls = 0
@@ -20,36 +50,6 @@ class ExperimentRunnerTest(TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.test_dir)
-
-    @register_plugin
-    class MockTrainer(TrainerABC):
-        def __init__(self, bool_param, int_param, str_param, float_param, env_param):
-            self.bool_param = bool_param
-            self.int_param = int_param
-            self.str_param = str_param
-            self.float_param = float_param
-            self.env_param = env_param
-            self.trained = False
-
-        def train(self):
-            ExperimentRunnerTest._trainer_calls += 1
-            if self.trained:
-                raise ValueError()
-            self.trained = True
-
-    @register_plugin
-    class MockReporter(ReporterABC):
-        def __init__(self):
-            self.reported = False
-
-        def report(self, name: str, experiment: ExperimentConfig, report_dir: Path):
-            ExperimentRunnerTest._configs[name] = experiment
-            ExperimentRunnerTest._reporter_calls += 1
-            if self.reported:
-                raise ValueError()
-
-            self.reported = True
-
 
     def test_run_all(self):
 

--- a/transfer_nlp/plugins/config.py
+++ b/transfer_nlp/plugins/config.py
@@ -74,13 +74,13 @@ def register_plugin(registrable: Any, alias: str = None):
     """
     if not alias:
         if registrable.__name__ in REGISTRY:
-            raise ValueError(f"{registrable.__name__} is already registered to class {REGISTRY[registrable.__name__]}. Please select another name")
+            raise ValueError(f"{registrable.__name__} is already registered to registrable {REGISTRY[registrable.__name__]}. Please select another name")
         else:
             REGISTRY[registrable.__name__] = registrable
             return registrable
     else:
         if alias in REGISTRY:
-            raise ValueError(f"{alias} is already registered to class {REGISTRY[alias]}. Please select another name")
+            raise ValueError(f"{alias} is already registered to registrable {REGISTRY[alias]}. Please select another name")
         else:
             REGISTRY[alias] = registrable
             return registrable
@@ -303,10 +303,10 @@ class ExperimentConfig:
         logger.info(f"Configuring {object_key}")
 
         if '_name' not in object_dict:
-            raise ValueError(f"The object {object_key} should have a _name key to access its class")
+            raise ValueError(f"The object {object_key} should have a _name key to access its registrable")
 
-        class_name = object_dict['_name']
-        registrable = REGISTRY.get(class_name)
+        registrable_name = object_dict['_name']
+        registrable = REGISTRY.get(registrable_name)
 
         if not registrable:
             raise UnknownPluginException(object_dict["_name"])
@@ -321,7 +321,7 @@ class ExperimentConfig:
             spec = inspect.getfullargspec(registrable)
             spec_args = spec.args[1:]
         else:
-            raise ValueError(f"{class_name} should be either a class, a function or a method")
+            raise ValueError(f"{registrable_name} should be either a class, a function or a method")
 
         params = {}
         param2config_key = {}
@@ -330,7 +330,7 @@ class ExperimentConfig:
 
         for named_param in named_params:
             if named_param not in spec_args:
-                raise BadParameter(registrable=class_name, param=named_param)
+                raise BadParameter(registrable=registrable_name, param=named_param)
 
         for arg in spec_args:
 

--- a/transfer_nlp/plugins/config.py
+++ b/transfer_nlp/plugins/config.py
@@ -63,10 +63,10 @@ CLASSES = {
 
 
 def register_plugin(clazz):
-    if clazz.__name__ in CLASSES:
-        raise ValueError(f"{clazz.__name__} is already registered to class {CLASSES[clazz.__name__]}. Please select another name")
+    if clazz.__qualname__ in CLASSES:
+        raise ValueError(f"{clazz.__qualname__} is already registered to class {CLASSES[clazz.__qualname__]}. Please select another name")
     else:
-        CLASSES[clazz.__name__] = clazz
+        CLASSES[clazz.__qualname__] = clazz
         return clazz
 
 

--- a/transfer_nlp/plugins/config.py
+++ b/transfer_nlp/plugins/config.py
@@ -62,12 +62,20 @@ CLASSES = {
 }
 
 
-def register_plugin(clazz):
-    if clazz.__qualname__ in CLASSES:
-        raise ValueError(f"{clazz.__qualname__} is already registered to class {CLASSES[clazz.__qualname__]}. Please select another name")
+def register_plugin(clazz, alias: str=None):
+    if not alias:
+        if clazz.__name__ in CLASSES:
+            raise ValueError(f"{clazz.__name__} is already registered to class {CLASSES[clazz.__name__]}. Please select another name")
+        else:
+            CLASSES[clazz.__name__] = clazz
+            return clazz
     else:
-        CLASSES[clazz.__qualname__] = clazz
-        return clazz
+        if alias in CLASSES:
+            raise ValueError(f"{alias} is already registered to class {CLASSES[alias]}. Please select another name")
+        else:
+            CLASSES[alias] = clazz
+            return clazz
+
 
 
 class UnknownPluginException(Exception):


### PR DESCRIPTION
In order to register methods and use them directly in the experiment json file, we change __name__ to __qualname__ in the `register_plugin__` method.
