### PR TITLE
return the cache object after sequential experiments

### DIFF
--- a/tests/runner/test_experiment_runner.py
+++ b/tests/runner/test_experiment_runner.py
@@ -39,6 +39,7 @@ class MockReporter(ReporterABC):
             raise ValueError()
 
         self.reported = True
+        return ExperimentRunnerTest._reporter_calls
 
 
 class ExperimentRunnerTest(TestCase):
@@ -61,8 +62,8 @@ class ExperimentRunnerTest(TestCase):
                                          trainer_config_name='the_trainer',
                                          reporter_config_name='the_reporter', ENV_PARAM='my_env_param',
                                          experiment_cache=pkg_dir / 'test_read_only.json')
-        self.assertIsInstance(cache, ExperimentConfig)
-        self.assertEqual(cache['another_trainer'].int_param, 1)
+        self.assertIsInstance(cache, dict)
+        self.assertEqual(cache, {"config1": 1, "config2": 2})
 
         self.assertEqual(2, ExperimentRunnerTest._reporter_calls)
         self.assertEqual(2, ExperimentRunnerTest._trainer_calls)

--- a/tests/runner/test_experiment_runner.py
+++ b/tests/runner/test_experiment_runner.py
@@ -56,14 +56,14 @@ class ExperimentRunnerTest(TestCase):
 
     def test_run_all(self):
         pkg_dir = Path(__file__).parent
-        cache = ExperimentRunner.run_all(experiment=pkg_dir / 'test_experiment.json',
+        aggregate_reports = ExperimentRunner.run_all(experiment=pkg_dir / 'test_experiment.json',
                                          experiment_config=pkg_dir / 'test_experiment.cfg',
                                          report_dir=self.test_dir + '/reports',
                                          trainer_config_name='the_trainer',
                                          reporter_config_name='the_reporter', ENV_PARAM='my_env_param',
                                          experiment_cache=pkg_dir / 'test_read_only.json')
-        self.assertIsInstance(cache, dict)
-        self.assertEqual(cache, {"config1": 1, "config2": 2})
+        self.assertIsInstance(aggregate_reports, dict)
+        self.assertEqual(aggregate_reports, {"config1": 1, "config2": 2})
 
         self.assertEqual(2, ExperimentRunnerTest._reporter_calls)
         self.assertEqual(2, ExperimentRunnerTest._trainer_calls)

--- a/tests/runner/test_experiment_runner.py
+++ b/tests/runner/test_experiment_runner.py
@@ -40,10 +40,12 @@ class MockReporter(ReporterABC):
 
         self.reported = True
 
+
 class ExperimentRunnerTest(TestCase):
     _reporter_calls = 0
     _trainer_calls = 0
     _configs = {}
+
     def setUp(self):
         _reporter_calls = 0
         self.test_dir = tempfile.mkdtemp()
@@ -52,13 +54,15 @@ class ExperimentRunnerTest(TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_run_all(self):
-
         pkg_dir = Path(__file__).parent
-        ExperimentRunner.run_all(experiment=pkg_dir/ 'test_experiment.json',
-                                 experiment_config=pkg_dir / 'test_experiment.cfg',
-                                 report_dir=self.test_dir + '/reports',
-                                 trainer_config_name='the_trainer',
-                                 reporter_config_name='the_reporter', ENV_PARAM='my_env_param')
+        cache = ExperimentRunner.run_all(experiment=pkg_dir / 'test_experiment.json',
+                                         experiment_config=pkg_dir / 'test_experiment.cfg',
+                                         report_dir=self.test_dir + '/reports',
+                                         trainer_config_name='the_trainer',
+                                         reporter_config_name='the_reporter', ENV_PARAM='my_env_param',
+                                         experiment_cache=pkg_dir / 'test_read_only.json')
+        self.assertIsInstance(cache, ExperimentConfig)
+        self.assertEqual(cache['another_trainer'].int_param, 1)
 
         self.assertEqual(2, ExperimentRunnerTest._reporter_calls)
         self.assertEqual(2, ExperimentRunnerTest._trainer_calls)
@@ -66,7 +70,6 @@ class ExperimentRunnerTest(TestCase):
         self.assertEqual(2, len(ExperimentRunnerTest._configs))
 
         for name, bparam, iparam, fparam, sparam in [('config1', True, 1, 1.5, 'hello'), ('config2', False, 2, 2.5, 'world')]:
-
             # assert params where substituted into the experiment properly
             cfg = ExperimentRunnerTest._configs[name]['the_trainer']
             self.assertEqual(bparam, cfg.bool_param)

--- a/tests/runner/test_read_only.json
+++ b/tests/runner/test_read_only.json
@@ -1,0 +1,10 @@
+{
+  "another_trainer": {
+    "_name": "MockTrainer",
+    "env_param": "ENV_PARAM",
+    "bool_param": true,
+    "int_param": 1,
+    "float_param": 3.0,
+    "str_param": "sparam"
+  }
+}

--- a/transfer_nlp/plugins/reporters.py
+++ b/transfer_nlp/plugins/reporters.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from pathlib import Path
+from typing import Any
 
 from transfer_nlp.plugins.config import ExperimentConfig
 
@@ -10,7 +11,7 @@ class ReporterABC(ABC):
     but can additionally produce reports that are easily machine-parsable.
     """
 
-    def report(self, experiment_name: str, experiment: ExperimentConfig, report_dir: Path) -> float:
+    def report(self, experiment_name: str, experiment: ExperimentConfig, report_dir: Path) -> Any:
         """
         report the results of an experiment
         :param experiment_name: the name of the experiment.

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -102,7 +102,7 @@ class ExperimentRunner:
                can preserve previous reports across code changes. E.g. $HOME/reports/run_2019_02_22.
         :param trainer_config_name: the name of the trainer configuration object. The referenced object should implement `TrainerABC`.
         :param reporter_config_name: the name of the reporter configuration object. The referenced object should implement `ReporterABC`.
-        :param experiment_cache: the config file containing read-only object, used for every experiment
+        :param experiment_cache: the experiment config with cached objects
         :param env_vars: any additional environment variables, like file system paths
         :return: None
         """

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -92,7 +92,7 @@ class ExperimentRunner:
                 trainer_config_name: str = 'trainer',
                 reporter_config_name: str = 'reporter',
                 experiment_cache: Union[str, Path, Dict] = None,
-                **env_vars) -> Union[ExperimentConfig, Dict]:
+                **env_vars) -> Dict[str, Any]:
         """
         :param experiment: the experiment config
         :param experiment_config: the experiment config file. The cfg file should be defined in `ConfigParser
@@ -118,6 +118,7 @@ class ExperimentRunner:
             experiment_config_cache = ExperimentConfig(experiment_cache, **env_vars)
             logging.info("#" * 5 + f"Read-only objects are built and cached for use in different experiment settings" + "#" * 5)
 
+        aggregate_reports = {}
         for exp_name, env in envs.items():
             exp_report_path = report_path / exp_name
             exp_report_path.mkdir()
@@ -139,8 +140,9 @@ class ExperimentRunner:
                 exp_json = ExperimentConfig.load_experiment_json(experiment)
                 exp_cache_json = ExperimentConfig.load_experiment_json(experiment_cache) if experiment_cache else None
                 ExperimentRunner._write_config(exp_name, exp_json, all_vars, exp_report_path, exp_cache_json)
-                reporter.report(exp_name, experiment_config, exp_report_path)
+                report = reporter.report(exp_name, experiment_config, exp_report_path)
+                aggregate_reports[exp_name] = report
             finally:
                 ExperimentRunner._stop_log_capture(log_handler)
-                
-        return experiment_config_cache
+
+        return aggregate_reports

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -104,7 +104,7 @@ class ExperimentRunner:
         :param reporter_config_name: the name of the reporter configuration object. The referenced object should implement `ReporterABC`.
         :param experiment_cache: the experiment config with cached objects
         :param env_vars: any additional environment variables, like file system paths
-        :return: None
+        :return: a dictionary containing report objects for every experiment config
         """
 
         envs: Dict[str, ConfigEnv] = load_config(Path(experiment_config))

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -92,7 +92,7 @@ class ExperimentRunner:
                 trainer_config_name: str = 'trainer',
                 reporter_config_name: str = 'reporter',
                 experiment_cache: Union[str, Path, Dict] = None,
-                **env_vars) -> None:
+                **env_vars) -> Union[ExperimentConfig, Dict]:
         """
         :param experiment: the experiment config
         :param experiment_config: the experiment config file. The cfg file should be defined in `ConfigParser
@@ -102,6 +102,7 @@ class ExperimentRunner:
                can preserve previous reports across code changes. E.g. $HOME/reports/run_2019_02_22.
         :param trainer_config_name: the name of the trainer configuration object. The referenced object should implement `TrainerABC`.
         :param reporter_config_name: the name of the reporter configuration object. The referenced object should implement `ReporterABC`.
+        :param experiment_cache: the config file containing read-only object, used for every experiment
         :param env_vars: any additional environment variables, like file system paths
         :return: None
         """
@@ -141,3 +142,5 @@ class ExperimentRunner:
                 reporter.report(exp_name, experiment_config, exp_report_path)
             finally:
                 ExperimentRunner._stop_log_capture(log_handler)
+                
+        return experiment_config_cache


### PR DESCRIPTION
One feedback we received is that it would be great to aggregate results from different config experiments. This is possible by recording the desired metrics into a custom Recorder object in the cache experiment file.
We only need to enable the user to use it after the sequential run.

Fixes #57 