### PR TITLE
Feature/yaml files

### DIFF
--- a/experiments/deep_learning_with_pytorch/mlp.toml
+++ b/experiments/deep_learning_with_pytorch/mlp.toml
@@ -1,0 +1,56 @@
+[my_dataset_splits]
+  _name = "SurnamesDatasetMLP"
+  data_file = "$HOME/surnames/surnames_with_splits.csv"
+  batch_size = 128
+
+  [my_dataset_splits.vectorizer]
+   _name = "SurnamesVectorizerMLP"
+   data_file = "$HOME/surnames/surnames_with_splits.csv"
+
+[model]
+  _name = "MultiLayerPerceptron"
+  hidden_dim = 100
+  data = "$my_dataset_splits"
+
+[optimizer]
+  _name = "Adam"
+  lr = 0.01
+
+  [optimizer.params]
+  _name = "TrainableParameters"
+
+[scheduler]
+  _name = "ReduceLROnPlateau"
+  patience = 1
+  mode = "min"
+  factor = 0.5
+
+[trainer]
+  _name = "SingleTaskTrainer"
+  model = "$model"
+  dataset_splits = "$my_dataset_splits"
+  optimizer = "$optimizer"
+  gradient_clipping = 0.25
+  num_epochs = 5
+  seed = 1337
+  tensorboard_logs = "$HOME/surnames/tensorboard/mlp"
+
+  [trainer.loss]
+  _name = "CrossEntropyLoss"
+
+  [trainer.regularizer]
+  _name = "L1"
+
+  [trainer.metrics]
+    [trainer.metrics.accuracy]
+    _name = "Accuracy"
+
+    [trainer.metrics.loss]
+    _name = "LossMetric"
+    [trainer.metrics.loss.loss_fn]
+        _name = "CrossEntropyLoss"
+
+[predictor]
+  _name = "MLPPredictor"
+  data = "$my_dataset_splits"
+  model = "$model"

--- a/experiments/deep_learning_with_pytorch/mlp.yml
+++ b/experiments/deep_learning_with_pytorch/mlp.yml
@@ -1,0 +1,50 @@
+my_dataset_splits:
+  _name: SurnamesDatasetMLP
+  data_file: $HOME/surnames/surnames_with_splits.csv
+  batch_size: 128
+  vectorizer:
+    _name: SurnamesVectorizerMLP
+    data_file: $HOME/surnames/surnames_with_splits.csv
+
+model:
+  _name: MultiLayerPerceptron
+  hidden_dim: 100
+  data: $my_dataset_splits
+
+optimizer:
+  _name: Adam
+  lr: 0.01
+  params:
+    _name: TrainableParameters
+
+scheduler:
+  _name: ReduceLROnPlateau
+  patience: 1
+  mode: min
+  factor: 0.5
+
+trainer:
+  _name: SingleTaskTrainer
+  model: $model
+  dataset_splits: $my_dataset_splits
+  loss:
+    _name: CrossEntropyLoss
+  optimizer: $optimizer
+  gradient_clipping: 0.25
+  num_epochs: 5
+  seed: 1337
+  regularizer:
+    _name: L1
+  tensorboard_logs: $HOME/surnames/tensorboard/mlp
+  metrics:
+    accuracy:
+      _name: Accuracy
+    loss:
+      _name: LossMetric
+      loss_fn:
+        _name: CrossEntropyLoss
+
+predictor:
+  _name: MLPPredictor
+  data: $my_dataset_splits
+  model: $model

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ smart_open>=1.8.1
 pytorch-ignite>=0.2.0
 torch>=1.1.0
 pyaml>=19.4.1
+toml>=0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.16.2
 smart_open>=1.8.1
 pytorch-ignite>=0.2.0
 torch>=1.1.0
+pyaml>=19.4.1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
         'numpy>=1.16.2',
         'torch>=1.1.0',
         'pytorch-ignite>=0.2.0',
-        'smart_open>=1.8.1'
+        'smart_open>=1.8.1',
+        'pyaml>=19.4.1'
     ],
     setup_requires=['green'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
         'torch>=1.1.0',
         'pytorch-ignite>=0.2.0',
         'smart_open>=1.8.1',
-        'pyaml>=19.4.1'
+        'pyaml>=19.4.1',
+        'toml>=0.10.0'
     ],
     setup_requires=['green'],
     classifiers=[

--- a/tests/runner/test_experiment_runner.py
+++ b/tests/runner/test_experiment_runner.py
@@ -89,5 +89,5 @@ class ExperimentRunnerTest(TestCase):
             self.assertEqual(sparam, cp.get(name, 'sparam'))
             self.assertEqual('my_env_param', cp.get(name, 'ENV_PARAM'))
 
-            self.assertEqual(ExperimentConfig.load_experiment_dict(pkg_dir / 'test_experiment.json'),
-                             ExperimentConfig.load_experiment_dict(f'{self.test_dir}/reports/{name}/experiment.json'))
+            self.assertEqual(ExperimentConfig.load_experiment_config(pkg_dir / 'test_experiment.json'),
+                             ExperimentConfig.load_experiment_config(f'{self.test_dir}/reports/{name}/experiment.json'))

--- a/tests/runner/test_experiment_runner.py
+++ b/tests/runner/test_experiment_runner.py
@@ -89,5 +89,5 @@ class ExperimentRunnerTest(TestCase):
             self.assertEqual(sparam, cp.get(name, 'sparam'))
             self.assertEqual('my_env_param', cp.get(name, 'ENV_PARAM'))
 
-            self.assertEqual(ExperimentConfig.load_experiment_json(pkg_dir / 'test_experiment.json'),
-                             ExperimentConfig.load_experiment_json(f'{self.test_dir}/reports/{name}/experiment.json'))
+            self.assertEqual(ExperimentConfig.load_experiment_dict(pkg_dir / 'test_experiment.json'),
+                             ExperimentConfig.load_experiment_dict(f'{self.test_dir}/reports/{name}/experiment.json'))

--- a/transfer_nlp/plugins/config.py
+++ b/transfer_nlp/plugins/config.py
@@ -15,6 +15,7 @@ from typing import Dict, Union, Any, Optional, AbstractSet, Set, List
 import ignite.metrics as metrics
 import torch.nn as nn
 import torch.optim as optim
+import yaml
 from smart_open import open
 
 logger = logging.getLogger(__name__)
@@ -84,7 +85,6 @@ def register_plugin(registrable: Any, alias: str = None):
         else:
             REGISTRY[alias] = registrable
             return registrable
-
 
 
 class UnknownPluginException(Exception):
@@ -204,12 +204,12 @@ def _replace_env_variables(dico: Dict, env: Dict) -> None:
 class ExperimentConfig:
 
     @staticmethod
-    def load_experiment_json(experiment: Union[str, Path, Dict]) -> Dict:
+    def load_experiment_dict(experiment: Union[str, Path, Dict]) -> Dict:
         if isinstance(experiment, dict):
             config = dict(experiment)
         else:
             with open(experiment) as f:
-                config = json.load(f)
+                config = yaml.safe_load(f)
         return config
 
     def __init__(self, experiment: Union[str, Path, Dict], **env):
@@ -221,7 +221,7 @@ class ExperimentConfig:
         self.factories: Dict[str, ConfigFactoryABC] = {}
         self.experiment: Dict[str, Any] = {}
 
-        config = ExperimentConfig.load_experiment_json(experiment)
+        config = ExperimentConfig.load_experiment_dict(experiment)
         _replace_env_variables(dico=config, env=env)
 
         # extract simple parameters

--- a/transfer_nlp/plugins/config.py
+++ b/transfer_nlp/plugins/config.py
@@ -4,7 +4,6 @@ This file contains all necessary plugins classes that the framework will use to 
 The Registry pattern used here is inspired from this post: https://realpython.com/primer-on-python-decorators/
 """
 import inspect
-import json
 import logging
 import os
 from abc import abstractmethod, ABC
@@ -256,7 +255,8 @@ class ExperimentConfig:
                         self.factories[factory_key] = self.factories[keyval]
                         return self.experiment[keyval]
                     else:
-                        raise UnconfiguredItemsException({factory_key: {val}})
+                        raise UnconfiguredItemsException({
+                                                             factory_key: {val}})
 
             return val
 
@@ -279,9 +279,9 @@ class ExperimentConfig:
                         for key in element:
                             if isinstance(element[key], dict):
                                 element[key] = self._do_recursive_build(object_key=key, object_dict=element[key],
-                                                                       default_params_mode=default_params_mode,
-                                                                       unconfigured_keys=unconfigured_keys,
-                                                                       parent_level=f'{parent_level}.{arg}.{i}.{key}')
+                                                                        default_params_mode=default_params_mode,
+                                                                        unconfigured_keys=unconfigured_keys,
+                                                                        parent_level=f'{parent_level}.{arg}.{i}.{key}')
 
                             elif isinstance(element[key], list):
                                 element[key] = do_recursive_build_list(list_object=element[key], arg_name=f"{arg_name}.{i}.{key}")
@@ -397,7 +397,8 @@ class ExperimentConfig:
 
         else:
             unconfigured_params = spec_args - params.keys()
-            raise UnconfiguredItemsException({parent_level: unconfigured_params})
+            raise UnconfiguredItemsException({
+                                                 parent_level: unconfigured_params})
 
     def _build_items_with_default_params_mode(self, config: Dict, default_params_mode: DefaultParamsMode):
 

--- a/transfer_nlp/plugins/config.py
+++ b/transfer_nlp/plugins/config.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Dict, Union, Any, Optional, AbstractSet, Set, List
 
 import ignite.metrics as metrics
+import toml
 import torch.nn as nn
 import torch.optim as optim
 import yaml
@@ -204,11 +205,17 @@ class ExperimentConfig:
 
     @staticmethod
     def load_experiment_dict(experiment: Union[str, Path, Dict]) -> Dict:
+        config = {}
         if isinstance(experiment, dict):
             config = dict(experiment)
         else:
             with open(experiment) as f:
-                config = yaml.safe_load(f)
+                if str(experiment).endswith(".json") or str(experiment).endswith(".yaml") or str(experiment).endswith(".yml"):
+                    config = yaml.safe_load(f)
+                elif str(experiment).endswith(".toml"):
+                    config = toml.load(f)
+                else:
+                    raise ValueError("Only Dict, json, yaml and toml experiment files are supported")
         return config
 
     def __init__(self, experiment: Union[str, Path, Dict], **env):
@@ -256,7 +263,7 @@ class ExperimentConfig:
                         return self.experiment[keyval]
                     else:
                         raise UnconfiguredItemsException({
-                                                             factory_key: {val}})
+                            factory_key: {val}})
 
             return val
 
@@ -398,7 +405,7 @@ class ExperimentConfig:
         else:
             unconfigured_params = spec_args - params.keys()
             raise UnconfiguredItemsException({
-                                                 parent_level: unconfigured_params})
+                parent_level: unconfigured_params})
 
     def _build_items_with_default_params_mode(self, config: Dict, default_params_mode: DefaultParamsMode):
 

--- a/transfer_nlp/plugins/config.py
+++ b/transfer_nlp/plugins/config.py
@@ -204,15 +204,16 @@ def _replace_env_variables(dico: Dict, env: Dict) -> None:
 class ExperimentConfig:
 
     @staticmethod
-    def load_experiment_dict(experiment: Union[str, Path, Dict]) -> Dict:
+    def load_experiment_config(experiment: Union[str, Path, Dict]) -> Dict:
         config = {}
         if isinstance(experiment, dict):
             config = dict(experiment)
         else:
-            with open(experiment) as f:
-                if str(experiment).endswith(".json") or str(experiment).endswith(".yaml") or str(experiment).endswith(".yml"):
+            experiment_path = Path(str(experiment)).expanduser()
+            with experiment_path.open() as f:
+                if experiment_path.suffix in {'.json', '.yaml', '.yml'}:
                     config = yaml.safe_load(f)
-                elif str(experiment).endswith(".toml"):
+                elif experiment_path.suffix in {'.toml'}:
                     config = toml.load(f)
                 else:
                     raise ValueError("Only Dict, json, yaml and toml experiment files are supported")
@@ -227,7 +228,7 @@ class ExperimentConfig:
         self.factories: Dict[str, ConfigFactoryABC] = {}
         self.experiment: Dict[str, Any] = {}
 
-        config = ExperimentConfig.load_experiment_dict(experiment)
+        config = ExperimentConfig.load_experiment_config(experiment)
         _replace_env_variables(dico=config, env=env)
 
         # extract simple parameters
@@ -262,8 +263,7 @@ class ExperimentConfig:
                         self.factories[factory_key] = self.factories[keyval]
                         return self.experiment[keyval]
                     else:
-                        raise UnconfiguredItemsException({
-                            factory_key: {val}})
+                        raise UnconfiguredItemsException({factory_key: {val}})
 
             return val
 

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -130,15 +130,15 @@ class ExperimentRunner:
 
                 exp = deepcopy(experiment)
                 if experiment_cache:
-                    exp = ExperimentConfig.load_experiment_json(exp)
+                    exp = ExperimentConfig.load_experiment_dict(exp)
                     exp.update(experiment_config_cache)
 
                 experiment_config = ExperimentConfig(exp, **all_vars)
                 trainer: TrainerABC = experiment_config[trainer_config_name]
                 reporter: ReporterABC = experiment_config[reporter_config_name]
                 trainer.train()
-                exp_json = ExperimentConfig.load_experiment_json(experiment)
-                exp_cache_json = ExperimentConfig.load_experiment_json(experiment_cache) if experiment_cache else None
+                exp_json = ExperimentConfig.load_experiment_dict(experiment)
+                exp_cache_json = ExperimentConfig.load_experiment_dict(experiment_cache) if experiment_cache else None
                 ExperimentRunner._write_config(exp_name, exp_json, all_vars, exp_report_path, exp_cache_json)
                 report = reporter.report(exp_name, experiment_config, exp_report_path)
                 aggregate_reports[exp_name] = report

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -130,15 +130,15 @@ class ExperimentRunner:
 
                 exp = deepcopy(experiment)
                 if experiment_cache:
-                    exp = ExperimentConfig.load_experiment_dict(exp)
+                    exp = ExperimentConfig.load_experiment_config(exp)
                     exp.update(experiment_config_cache)
 
                 experiment_config = ExperimentConfig(exp, **all_vars)
                 trainer: TrainerABC = experiment_config[trainer_config_name]
                 reporter: ReporterABC = experiment_config[reporter_config_name]
                 trainer.train()
-                exp_json = ExperimentConfig.load_experiment_dict(experiment)
-                exp_cache_json = ExperimentConfig.load_experiment_dict(experiment_cache) if experiment_cache else None
+                exp_json = ExperimentConfig.load_experiment_config(experiment)
+                exp_cache_json = ExperimentConfig.load_experiment_config(experiment_cache) if experiment_cache else None
                 ExperimentRunner._write_config(exp_name, exp_json, all_vars, exp_report_path, exp_cache_json)
                 report = reporter.report(exp_name, experiment_config, exp_report_path)
                 aggregate_reports[exp_name] = report


### PR DESCRIPTION
This PR addresses issue #60 :

Add support for YAML and TOML experiment files, in addition to the existing json experiment files.
An example of `mlp.json` experiment is ported to `mlp.toml` and `mlp.yml` as examples in `/experiments/deep_learning_with_pytorch/`

The goal is that the Config loader loads these files and build the usual experiment dictionnary so everything else stays the same.