### PR TITLE
Global reporting

### DIFF
--- a/tests/runner/test_experiment_runner.py
+++ b/tests/runner/test_experiment_runner.py
@@ -43,11 +43,11 @@ class MockReporter(ReporterABC):
 
         self.reported = True
         return ExperimentRunnerTest._reporter_calls
-    
+
     @staticmethod
-    def report_globally(aggregate_reports: Dict) -> Any:
+    def report_globally(aggregate_reports: Dict, report_dir: Path) -> Any:
         print("global reporting message")
-            
+
 
 class ExperimentRunnerTest(TestCase):
     _reporter_calls = 0
@@ -65,14 +65,16 @@ class ExperimentRunnerTest(TestCase):
     def test_run_all(self, mock_stdout):
         pkg_dir = Path(__file__).parent
         aggregate_reports = ExperimentRunner.run_all(experiment=pkg_dir / 'test_experiment.json',
-                                         experiment_config=pkg_dir / 'test_experiment.cfg',
-                                         report_dir=self.test_dir + '/reports',
-                                         trainer_config_name='the_trainer',
-                                         reporter_config_name='the_reporter', ENV_PARAM='my_env_param',
-                                         experiment_cache=pkg_dir / 'test_read_only.json')
+                                                     experiment_config=pkg_dir / 'test_experiment.cfg',
+                                                     report_dir=self.test_dir + '/reports',
+                                                     trainer_config_name='the_trainer',
+                                                     reporter_config_name='the_reporter', ENV_PARAM='my_env_param',
+                                                     experiment_cache=pkg_dir / 'test_read_only.json')
         self.assertEqual(mock_stdout.getvalue(), "global reporting message\n")
         self.assertIsInstance(aggregate_reports, dict)
-        self.assertEqual(aggregate_reports, {"config1": 1, "config2": 2})
+        self.assertEqual(aggregate_reports, {
+            "config1": 1,
+            "config2": 2})
 
         self.assertEqual(2, ExperimentRunnerTest._reporter_calls)
         self.assertEqual(2, ExperimentRunnerTest._trainer_calls)

--- a/tests/runner/test_experiment_runner.py
+++ b/tests/runner/test_experiment_runner.py
@@ -1,8 +1,11 @@
 import configparser
+import io
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Dict, Any
 from unittest import TestCase
+from unittest.mock import patch
 
 from transfer_nlp.plugins.config import register_plugin, ExperimentConfig
 from transfer_nlp.plugins.reporters import ReporterABC
@@ -40,7 +43,11 @@ class MockReporter(ReporterABC):
 
         self.reported = True
         return ExperimentRunnerTest._reporter_calls
-
+    
+    @staticmethod
+    def report_globally(aggregate_reports: Dict) -> Any:
+        print("global reporting message")
+            
 
 class ExperimentRunnerTest(TestCase):
     _reporter_calls = 0
@@ -54,7 +61,8 @@ class ExperimentRunnerTest(TestCase):
     def tearDown(self):
         shutil.rmtree(self.test_dir)
 
-    def test_run_all(self):
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_run_all(self, mock_stdout):
         pkg_dir = Path(__file__).parent
         aggregate_reports = ExperimentRunner.run_all(experiment=pkg_dir / 'test_experiment.json',
                                          experiment_config=pkg_dir / 'test_experiment.cfg',
@@ -62,6 +70,7 @@ class ExperimentRunnerTest(TestCase):
                                          trainer_config_name='the_trainer',
                                          reporter_config_name='the_reporter', ENV_PARAM='my_env_param',
                                          experiment_cache=pkg_dir / 'test_read_only.json')
+        self.assertEqual(mock_stdout.getvalue(), "global reporting message\n")
         self.assertIsInstance(aggregate_reports, dict)
         self.assertEqual(aggregate_reports, {"config1": 1, "config2": 2})
 

--- a/transfer_nlp/plugins/reporters.py
+++ b/transfer_nlp/plugins/reporters.py
@@ -21,12 +21,13 @@ class ReporterABC(ABC):
         """
 
         pass
-    
+
     @staticmethod
-    def report_globally(aggregate_reports: Dict) -> Any:
+    def report_globally(aggregate_reports: Dict, report_dir: Path) -> Any:
         """
         do a global reporting for multiple experiment configurations
         :param aggregate_reports: the result of report() on each experiment config.
+        :param report_dir: the directory in which to write the report
         :return: a global reporting of the key metric values along different configurations.
         """
         pass

--- a/transfer_nlp/plugins/reporters.py
+++ b/transfer_nlp/plugins/reporters.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 from transfer_nlp.plugins.config import ExperimentConfig
 
@@ -20,4 +20,13 @@ class ReporterABC(ABC):
         :return: the key metric value, it's assumed higher is better.
         """
 
+        pass
+    
+    @staticmethod
+    def report_globally(aggregate_reports: Dict) -> Any:
+        """
+        do a global reporting for multiple experiment configurations
+        :param aggregate_reports: the result of report() on each experiment config.
+        :return: a global reporting of the key metric values along different configurations.
+        """
         pass

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -145,4 +145,6 @@ class ExperimentRunner:
             finally:
                 ExperimentRunner._stop_log_capture(log_handler)
 
+        experiment_config[reporter_config_name].__class__.report_globally(aggregate_reports=aggregate_reports)
+
         return aggregate_reports

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -145,6 +145,6 @@ class ExperimentRunner:
             finally:
                 ExperimentRunner._stop_log_capture(log_handler)
 
-        experiment_config[reporter_config_name].__class__.report_globally(aggregate_reports=aggregate_reports)
+        experiment_config[reporter_config_name].__class__.report_globally(aggregate_reports=aggregate_reports, report_dir=report_path)
 
         return aggregate_reports

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -4,7 +4,7 @@ import logging
 from collections import OrderedDict
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Any, Union
+from typing import Dict, Any, Union, Type
 
 from transfer_nlp.plugins.config import ExperimentConfig
 from transfer_nlp.plugins.reporters import ReporterABC
@@ -145,6 +145,8 @@ class ExperimentRunner:
             finally:
                 ExperimentRunner._stop_log_capture(log_handler)
 
-        experiment_config[reporter_config_name].__class__.report_globally(aggregate_reports=aggregate_reports, report_dir=report_path)
+        reporter_class = experiment_config[reporter_config_name].__class__
+        if issubclass(reporter_class, ReporterABC):
+            reporter_class.report_globally(aggregate_reports=aggregate_reports, report_dir=report_path)
 
         return aggregate_reports


### PR DESCRIPTION
In this PR, we allow users to have a global reporting at the end of the sequential experiment running.

A user here would have to implement how she wants to aggregate reporting using the results of every config's reporting