### PR TITLE
Return experiment cache instead of aggregated reportings

### DIFF
--- a/tests/runner/test_experiment_runner.py
+++ b/tests/runner/test_experiment_runner.py
@@ -64,17 +64,17 @@ class ExperimentRunnerTest(TestCase):
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_run_all(self, mock_stdout):
         pkg_dir = Path(__file__).parent
-        aggregate_reports = ExperimentRunner.run_all(experiment=pkg_dir / 'test_experiment.json',
+        experiment_cache = ExperimentRunner.run_all(experiment=pkg_dir / 'test_experiment.json',
                                                      experiment_config=pkg_dir / 'test_experiment.cfg',
                                                      report_dir=self.test_dir + '/reports',
                                                      trainer_config_name='the_trainer',
                                                      reporter_config_name='the_reporter', ENV_PARAM='my_env_param',
                                                      experiment_cache=pkg_dir / 'test_read_only.json')
+        
         self.assertEqual(mock_stdout.getvalue(), "global reporting message\n")
-        self.assertIsInstance(aggregate_reports, dict)
-        self.assertEqual(aggregate_reports, {
-            "config1": 1,
-            "config2": 2})
+        self.assertIsInstance(experiment_cache['another_trainer'], MockTrainer)
+        self.assertEqual(experiment_cache['another_trainer'].int_param, 1)
+        self.assertEqual(experiment_cache['another_trainer'].bool_param, True)
 
         self.assertEqual(2, ExperimentRunnerTest._reporter_calls)
         self.assertEqual(2, ExperimentRunnerTest._trainer_calls)

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -104,7 +104,7 @@ class ExperimentRunner:
         :param reporter_config_name: the name of the reporter configuration object. The referenced object should implement `ReporterABC`.
         :param experiment_cache: the experiment config with cached objects
         :param env_vars: any additional environment variables, like file system paths
-        :return: a dictionary containing report objects for every experiment config
+        :return: the experiment cache
         """
 
         envs: Dict[str, ConfigEnv] = load_config(Path(experiment_config))
@@ -149,4 +149,4 @@ class ExperimentRunner:
         if issubclass(reporter_class, ReporterABC):
             reporter_class.report_globally(aggregate_reports=aggregate_reports, report_dir=report_path)
 
-        return aggregate_reports
+        return experiment_config_cache


### PR DESCRIPTION
After the latest PR, there were no use of the returned aggregated reportings from the runner `run_all` method.

In this PR, we change this behavior by returning the experiment cache instead, as it is quite helpful in contexts where the cached objects need to be accessed after `runn_all()`