### PR TITLE
Enable dicts as first objects

### DIFF
--- a/tests/plugins/test_config.py
+++ b/tests/plugins/test_config.py
@@ -123,19 +123,18 @@ class Pipeline:
 
     def __init__(self, steps: List):
         self.steps = steps
-   
+
 
 class DemoClassMethod:
-    
+
     def __init__(self, param: int):
-        
         self.param = param
-    
+
     @classmethod
     def from_example(cls):
         return cls(1)
-    
-    
+
+
 register_plugin(DemoClassMethod.from_example, alias='from_example_alias_name')
 
 
@@ -156,9 +155,36 @@ class ClassWithUnInstantiatedObject:
         self.my_function = my_function
 
 
-
-
 class RegistryTest(unittest.TestCase):
+
+    def test_dict_of_registrables(self):
+
+        experiment = {
+            "first_object": {
+                "_name": "DemoWithVal",
+                "val": 2
+            },
+            "dict_of_objects": {
+
+                "first_obbject":
+                    {
+                        "_name": "DemoWithVal",
+                        "val": 1
+                    },
+                "second_object":
+                    {
+                        "_name": "DemoWithStr",
+                        "strval": "foo"
+                    },
+                "simple_object": 1
+
+            }
+        }
+
+        e = ExperimentConfig(experiment)
+        self.assertEqual(e['dict_of_objects']['first_obbject'].val, 1)
+        self.assertEqual(e['dict_of_objects']['second_object'].strval, 'foo')
+        self.assertEqual(e['dict_of_objects']['simple_object'], 1)
 
     def test_list_of_registrables(self):
         experiment = {
@@ -193,9 +219,9 @@ class RegistryTest(unittest.TestCase):
         self.assertEqual(e['list_of_objects'][4], 'feedly')
         self.assertEqual(e['list_of_objects'][5](), 5)
         self.assertEqual(e['list_of_objects'][6](), 2)
-        
-    def test_all_string_with_dollars(self): 
-        
+
+    def test_all_string_with_dollars(self):
+
         experiment = {
             "first_object": {
                 "_name": "DemoWithVal",
@@ -226,7 +252,7 @@ class RegistryTest(unittest.TestCase):
         self.assertEqual(e['my_registrable'].my_function(), 5)
 
     def test_class_method(self):
-        
+
         experiment = {
             "my_object": {
                 "_name": "from_example_alias_name"
@@ -362,7 +388,6 @@ class RegistryTest(unittest.TestCase):
         self.assertEqual(e['data2'].param_list[0].is_available, '/tmp')
         self.assertEqual(e['data2'].param_list[1].is_available, True)
         self.assertEqual(e['data2'].param_list[2], '/tmp2')
-
 
     def test_literal_injection(self):
         experiment = {

--- a/tests/plugins/test_config.py
+++ b/tests/plugins/test_config.py
@@ -166,7 +166,7 @@ class RegistryTest(unittest.TestCase):
             },
             "dict_of_objects": {
 
-                "first_obbject":
+                "first_object":
                     {
                         "_name": "DemoWithVal",
                         "val": 1
@@ -176,15 +176,17 @@ class RegistryTest(unittest.TestCase):
                         "_name": "DemoWithStr",
                         "strval": "foo"
                     },
-                "simple_object": 1
+                "simple_object": 1,
+                "last_object": "$first_object"
 
             }
         }
 
         e = ExperimentConfig(experiment)
-        self.assertEqual(e['dict_of_objects']['first_obbject'].val, 1)
+        self.assertEqual(e['dict_of_objects']['first_object'].val, 1)
         self.assertEqual(e['dict_of_objects']['second_object'].strval, 'foo')
         self.assertEqual(e['dict_of_objects']['simple_object'], 1)
+        self.assertEqual(e['dict_of_objects']['last_object'].val, 2)
 
     def test_list_of_registrables(self):
         experiment = {

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -92,7 +92,7 @@ class ExperimentRunner:
                 trainer_config_name: str = 'trainer',
                 reporter_config_name: str = 'reporter',
                 experiment_cache: Union[str, Path, Dict] = None,
-                **env_vars) -> Dict[str, Any]:
+                **env_vars) -> ExperimentConfig:
         """
         :param experiment: the experiment config
         :param experiment_config: the experiment config file. The cfg file should be defined in `ConfigParser


### PR DESCRIPTION
Similarly to #66 with lists, we currently can't have complex dictionaries as first objects in the experiment file. This PR allows for this, e.g.:

```
my_object:
  first_key:
    _name: FirstClass
  second_key:
    _name: SecondClass
```

(previously an error with "no '_name' param" would have been raised)