### PR TITLE
simplify configs reporting

### DIFF
--- a/tests/runner/test_experiment.yml
+++ b/tests/runner/test_experiment.yml
@@ -1,0 +1,12 @@
+the_trainer:
+  _name: MockTrainer
+  env_param: $ENV_PARAM
+  bool_param: $bparam
+  int_param: $iparam
+  float_param: $fparam
+  str_param: $sparam
+
+the_reporter:
+  _name: MockReporter
+
+lobjects: $lobjects


### PR DESCRIPTION
This PR does a few things:

- Get rid of ini `.cfg` files saving
- Before doing the sequential experiments, we copy the configs, experiment and cache files to a global-reporting directory.
- This global-reporting directory will also host the outputs from the reporter's `report_globally()` call