### PR TITLE
move trainerABC to separate file

### DIFF
--- a/transfer_nlp/plugins/trainer_abc.py
+++ b/transfer_nlp/plugins/trainer_abc.py
@@ -1,0 +1,8 @@
+from abc import ABC, abstractmethod
+
+
+class TrainerABC(ABC):
+
+    @abstractmethod
+    def train(self):
+        pass

--- a/transfer_nlp/plugins/trainers.py
+++ b/transfer_nlp/plugins/trainers.py
@@ -11,7 +11,7 @@ the NAACL 2019 tutorial on TRansfer Learning for NLP https://colab.research.goog
 import inspect
 import logging
 import re
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections import defaultdict
 from typing import Dict, List, Any, Union, Tuple
 
@@ -30,6 +30,7 @@ from ignite.utils import convert_tensor
 from transfer_nlp.loaders.loaders import DatasetSplits
 from transfer_nlp.plugins.config import register_plugin
 from transfer_nlp.plugins.regularizers import RegularizerABC
+from transfer_nlp.plugins.trainer_abc import TrainerABC
 
 logger = logging.getLogger(__name__)
 
@@ -92,13 +93,6 @@ class TrainingMetric(Metric):
 
     def compute(self):
         return self.source_metric.compute()
-
-
-class TrainerABC(ABC):
-
-    @abstractmethod
-    def train(self):
-        pass
 
 
 @register_plugin

--- a/transfer_nlp/runner/experiment_runner.py
+++ b/transfer_nlp/runner/experiment_runner.py
@@ -9,7 +9,7 @@ import toml
 
 from transfer_nlp.plugins.config import ExperimentConfig
 from transfer_nlp.plugins.reporters import ReporterABC
-from transfer_nlp.plugins.trainers import TrainerABC
+from transfer_nlp.plugins.trainer_abc import TrainerABC
 
 ConfigEnv = Dict[str, Any]
 


### PR DESCRIPTION
This PR moves the TrainerABC class to a separate file.
Therefore, someone willing to use the experiment runner class can do so without having to install torch