### PR TITLE
Optional torch imports for trainers

### DIFF
--- a/tests/plugins/test_trainer.py
+++ b/tests/plugins/test_trainer.py
@@ -12,8 +12,6 @@ from transfer_nlp.plugins.config import ExperimentConfig
 from transfer_nlp.plugins.regularizers import L1
 from .trainer_utils import *
 
-from transfer_nlp.plugins import regularizers, helpers, trainers, metrics as m
-
 PLUGINS = {
     'CrossEntropyLoss': nn.CrossEntropyLoss,
     'BCEWithLogitsLoss': nn.BCEWithLogitsLoss,

--- a/tests/plugins/test_trainer.py
+++ b/tests/plugins/test_trainer.py
@@ -12,6 +12,8 @@ from transfer_nlp.plugins.config import ExperimentConfig
 from transfer_nlp.plugins.regularizers import L1
 from .trainer_utils import *
 
+from transfer_nlp.plugins import regularizers, helpers, trainers, metrics as m
+
 PLUGINS = {
     'CrossEntropyLoss': nn.CrossEntropyLoss,
     'BCEWithLogitsLoss': nn.BCEWithLogitsLoss,

--- a/transfer_nlp/__init__.py
+++ b/transfer_nlp/__init__.py
@@ -1,0 +1,9 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    from transfer_nlp.plugins import metrics, regularizers, helpers, trainers
+    logger.debug("Using trainers with Torch utilities")
+except ImportError as e:
+    logger.debug("Using trainers without Torch utilities")

--- a/transfer_nlp/__init__.py
+++ b/transfer_nlp/__init__.py
@@ -1,1 +1,0 @@
-from transfer_nlp.plugins import metrics, regularizers, helpers, trainers


### PR DESCRIPTION
We import torch modules in the `__init__.py` of trainers.
This PR makes these imports optional, in the case where we don't have torch installed but still want to use the base TrainerABC class